### PR TITLE
Add tcp transport test

### DIFF
--- a/network/local_transport_test.go
+++ b/network/local_transport_test.go
@@ -17,13 +17,9 @@ func TestConnect(t *testing.T) {
 	assert.NoError(t, err)
 	//assert.NoError(t, trb.Connect(tra))
 
-	gotB, exists := tra.Get(trb.Addr())
-	assert.True(t, exists)
-	assert.Equal(t, trb, gotB)
+	assert.True(t, tra.IsConnected(trb.Addr()))
 
-	gotA, exists := trb.Get(tra.Addr())
-	assert.True(t, exists)
-	assert.Equal(t, tra, gotA)
+	assert.True(t, trb.IsConnected(tra.Addr()))
 
 	p := CreatePayload([]byte("hi"))
 	assert.NoError(t, tra.Send(trb.addr, p))
@@ -33,37 +29,6 @@ func TestConnect(t *testing.T) {
 	b, err := ioutil.ReadAll(got.Content)
 	assert.NoError(t, err)
 	assert.Equal(t, p.data, b)
-	assert.Equal(t, tra.addr, got.From)
-
-}
-
-func TestLocalTransport_Broadcast(t *testing.T) {
-
-	trA := NewLocalTransport(LocalAddr("a"))
-	trB := NewLocalTransport(LocalAddr("b"))
-	trC := NewLocalTransport(LocalAddr("c"))
-
-	trA.Connect(trB)
-	trA.Connect(trC)
-	payload := CreatePayload([]byte("hi there"))
-
-	assert.NoError(t, trA.Broadcast(payload))
-
-	rpcB := <-trB.Recv()
-	assert.Equal(t, trA.Addr(), rpcB.From)
-
-	gotB := make([]byte, len(payload.data))
-
-	n, err := rpcB.Content.Read(gotB)
-	assert.Equal(t, n, len(payload.data))
-
-	assert.NoError(t, err)
-	assert.Equal(t, payload.data, gotB)
-
-	rpcC := <-trC.Recv()
-	assert.Equal(t, trA.Addr(), rpcC.From)
-	gotC, err := ioutil.ReadAll(rpcC.Content)
-	assert.NoError(t, err)
-	assert.Equal(t, payload.data, gotC)
+	assert.Equal(t, tra.addr.String(), got.From)
 
 }

--- a/network/rpc.go
+++ b/network/rpc.go
@@ -4,19 +4,19 @@ import (
 	"bytes"
 	"encoding/gob"
 	"io"
-	"net"
 )
 
 type RPC struct {
 	// message sent over transport layer
-	From net.Addr
+	//	From net.Addr
+	From string
 	// this is totally generic
 	Content io.Reader
 }
 
 // generic deserialization for consuming RPCs
 type DecodedMessage struct {
-	From net.Addr
+	From string
 	// this is generic because the transport layer can send anything
 	Data any
 }

--- a/network/tcp_transport_test.go
+++ b/network/tcp_transport_test.go
@@ -1,0 +1,52 @@
+package network
+
+import (
+	"io/ioutil"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTcpConnect(t *testing.T) {
+
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	ad := l.Addr()
+	t.Logf(" hack addr %s", l.Addr().String())
+	l.Close()
+	//a := netip.MustParseAddrPort(ad.String())
+	tra, err := NewTcpTransport(ad) //NewLocalTransport(LocalAddr("A"))
+	require.NoError(t, err)
+
+	l, err = net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	ad2 := l.Addr()
+	t.Logf(" hack addr %s", l.Addr().String())
+	l.Close()
+
+	//b := netip.MustParseAddrPort("127.0.0.1:0")
+
+	trb, err := NewTcpTransport(ad2) //NewLocalTransport(LocalAddr("B"))
+	require.NoError(t, err)
+
+	t.Logf("connecting a->b... %+v -> %+v ", tra.Addr(), trb.Addr())
+
+	err = tra.Connect(trb)
+	assert.NoError(t, err)
+	t.Log("  done connecting a->b")
+
+	assert.True(t, tra.IsConnected(trb.Addr()))
+
+	p := CreatePayload([]byte("hi"))
+	assert.NoError(t, tra.Send(trb.addr, p))
+
+	got := <-trb.Recv()
+
+	bt, err := ioutil.ReadAll(got.Content)
+	assert.NoError(t, err)
+	assert.Equal(t, p.data, bt)
+	assert.Equal(t, tra.addr.String(), got.From)
+
+}

--- a/network/transport.go
+++ b/network/transport.go
@@ -14,9 +14,7 @@ type Transport interface {
 	Send(net.Addr, Payload) error
 	Addr() net.Addr
 
-	Get(net.Addr) (Transport, bool)
-	// transport is agnostic to the types in the payload
-	Broadcast(payload Payload) error
+	IsConnected(net.Addr) bool
 }
 
 type Payload struct {

--- a/notes.txt
+++ b/notes.txt
@@ -1,3 +1,25 @@
+Implement TCP transport
+
+The big learning lesson is that we fucked up the initial transport design.
+
+We knew that we want to get to TCP, UDP eventually. But we didn't really think ahead to that very much. 
+
+Simple things that would have helped alot:
+Seperate the transport and connections -- our local transport should have between composed of local connections that implement
+a subset of of the net.Conn interface
+
+this would have made us use a standard interface for connections, which would be easier to implement for other kinds of connections.
+
+basically we mixed up the transport and the connections. this pain was also felt in the local transport refactor that had to go into
+supporting syncing blocks. in that case, we needs to make the local transport bi directional. ultimately we needed bi-directional connections
+by intermingling the transport and connections, we made a lot of extra work for ourselves.
+
+said differently, even though we didn't know exactly what we wanted to build a little more 'standing on the shoulders giants' by
+adopting and conforming to standard interfaces and composition would have saved a ton to later work. it's a good lesson.
+
+
+
+
 Refactoring transport in support of block syncing
 Refactor transport connections
 

--- a/server/handle_subscribe.go
+++ b/server/handle_subscribe.go
@@ -13,19 +13,19 @@ func (s *Server) handleSubscribeMessageRequest(smsg *api.SubscribeMessageRequest
 	)
 
 	// add the requestor to my peers
-	tr, exists := s.Transport.Get(smsg.RequestorAddr)
+	exists := s.Transport.IsConnected(smsg.RequestorAddr)
 	if !exists {
 		return fmt.Errorf("subscription request from ghost connection %+v", smsg)
 	}
 
-	s.PeerTransports = append(s.PeerTransports, tr)
+	s.Peers = append(s.Peers, smsg.RequestorAddr)
 
 	resp, err := api.NewMessageFromSubscribeMessageResponse(new(api.SubscribeMessageResponse))
 	if err != nil {
 		return err
 	}
 
-	return s.send(tr.Addr(), resp)
+	return s.send(smsg.RequestorAddr, resp)
 }
 
 func (s *Server) handleSubscribeMessageResponse(smsg *api.SubscribeMessageResponse) error {

--- a/server/rpc_decode_func_test.go
+++ b/server/rpc_decode_func_test.go
@@ -76,7 +76,7 @@ func messageToRpc(t *testing.T, msg *api.Message) network.RPC {
 	payload := network.CreatePayload(d)
 
 	return network.RPC{
-		From:    network.LocalAddr("test-sender"),
+		From:    network.LocalAddr("test-sender").String(),
 		Content: payload.Reader(),
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"math/rand"
+	"net"
 	"sync"
 
 	"fmt"
@@ -27,14 +28,14 @@ type ServerOpts struct {
 	ID        string
 	Transport network.Transport
 	// multiple transport layers
-	PeerTransports []network.Transport
-	PrivateKey     crypto.PrivateKey
-	BlockTime      time.Duration
-	TxHasher       core.Hasher[*core.Transaction]
-	Logger         *zap.Logger
-	RPCDecodeFunc  network.RPCDecodeFunc
-	RPCProcessor   network.RPCProcessor
-	Blockchain     *core.Blockchain
+	Peers         []net.Addr
+	PrivateKey    crypto.PrivateKey
+	BlockTime     time.Duration
+	TxHasher      core.Hasher[*core.Transaction]
+	Logger        *zap.Logger
+	RPCDecodeFunc network.RPCDecodeFunc
+	RPCProcessor  network.RPCProcessor
+	Blockchain    *core.Blockchain
 }
 
 type Server struct {
@@ -166,54 +167,54 @@ func (s *Server) ProcessMessage(dmsg *network.DecodedMessage) error {
 	case *core.Transaction:
 		s.logger.Info("ProcessMessage",
 			zap.String("type", api.MessageTypeTx.String()),
-			zap.String("from", dmsg.From.String()))
+			zap.String("from", dmsg.From))
 
 		return s.handleTransaction(t)
 	case *core.Block:
 		s.logger.Info("ProcessMessage",
 			zap.String("type", api.MessageTypeBlock.String()),
-			zap.String("from", dmsg.From.String()))
+			zap.String("from", dmsg.From))
 		return s.handleBlock(t)
 	case *api.StatusMessageRequest:
 		s.logger.Info("ProcessMessage",
 			zap.String("type", api.MessageTypeStatusRequest.String()),
-			zap.String("from", dmsg.From.String()))
+			zap.String("from", dmsg.From))
 		return s.handleStatusMessageRequest(t)
 
 	case *api.StatusMessageResponse:
 		s.logger.Info("ProcessMessage",
 			zap.String("type", api.MessageTypeStatusResponse.String()),
-			zap.String("from", dmsg.From.String()))
+			zap.String("from", dmsg.From))
 		return s.handleStatusMessageResponse(t)
 
 	case *api.SubscribeMessageRequest:
 		s.logger.Info("ProcessMessage",
 			zap.String("type", api.MessageTypeSubscribeRequest.String()),
-			zap.String("from", dmsg.From.String()))
+			zap.String("from", dmsg.From))
 		return s.handleSubscribeMessageRequest(t)
 
 	case *api.SubscribeMessageResponse:
 		s.logger.Info("ProcessMessage",
 			zap.String("type", api.MessageTypeSubscribeResponse.String()),
-			zap.String("from", dmsg.From.String()))
+			zap.String("from", dmsg.From))
 		return s.handleSubscribeMessageResponse(t)
 
 	case *api.GetBlocksRequest:
 		s.logger.Info("ProcessMessage",
 			zap.String("type", api.MessageTypeGetBlocksRequest.String()),
-			zap.String("from", dmsg.From.String()))
+			zap.String("from", dmsg.From))
 		return s.handleGetBlocksRequest(t)
 
 	case *api.GetBlocksResponse:
 		s.logger.Info("ProcessMessage",
 			zap.String("type", api.MessageTypeGetBlocksResponse.String()),
-			zap.String("from", dmsg.From.String()))
+			zap.String("from", dmsg.From))
 		return s.handleGetBlocksResponse(t)
 
 	default:
 		s.logger.Info("ProcessMessage",
 			zap.Any("type", t),
-			zap.String("from", dmsg.From.String()))
+			zap.String("from", dmsg.From))
 
 		return fmt.Errorf("invalid decoded message %v", t)
 	}

--- a/server/server_internal.go
+++ b/server/server_internal.go
@@ -132,11 +132,11 @@ func (s *Server) broadcastTx(tx *core.Transaction) error {
 }
 
 func (s *Server) broadcast(msg *api.Message) error {
-	if len(s.PeerTransports) == 0 {
+	if len(s.Peers) == 0 {
 		s.logger.Warn("broadcasting without peers")
 	}
-	for _, peer := range s.PeerTransports {
-		err := s.send(peer.Addr(), msg)
+	for _, peer := range s.Peers {
+		err := s.send(peer, msg)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
this was labrious because we had been tracking From net.Addr in the RPC

this doesnt work well for a number of reasons. the biggest is serialization of a net.Addr across the network. ultimately, we didn't need net.Addr, we were only using it as a key to map - a string id works fine.

other than that, had to implement message parsing on top of the tcp protocol

there is much room for improvement of factor out the current parsing from the read loop into some testable funcs

deleted the Broadcast from Transport interface because it wasn't used