### PR TITLE
Refactor the public key

### DIFF
--- a/core/coding.go
+++ b/core/coding.go
@@ -1,17 +1,9 @@
 package core
 
 import (
-	"crypto/elliptic"
 	"encoding/gob"
 	"io"
 )
-
-func init() {
-	// ensure the that gob can handle the all the dependencies
-	// in our transactions
-	gob.Register(elliptic.P256())
-
-}
 
 type Encoder[T any] interface {
 	Encode(T) error

--- a/crypto/keypair.go
+++ b/crypto/keypair.go
@@ -29,10 +29,11 @@ func MustGeneratePrivateKey() PrivateKey {
 func (k PrivateKey) IsZero() bool {
 	return k.key == nil
 }
+
 func (k PrivateKey) PublicKey() PublicKey {
-	return PublicKey{
-		Key: &k.key.PublicKey,
-	}
+	return elliptic.MarshalCompressed(k.key.PublicKey,
+		k.key.PublicKey.X,
+		k.key.PublicKey.Y)
 }
 
 func (k PrivateKey) Sign(data []byte) (*Signature, error) {
@@ -46,12 +47,10 @@ func (k PrivateKey) Sign(data []byte) (*Signature, error) {
 		R: r}, nil
 }
 
-type PublicKey struct {
-	Key *ecdsa.PublicKey
-}
+type PublicKey []byte
 
 func (k PublicKey) ToSlice() []byte {
-	return elliptic.MarshalCompressed(k.Key, k.Key.X, k.Key.Y)
+	return k
 
 }
 
@@ -68,5 +67,13 @@ type Signature struct {
 }
 
 func (s *Signature) Verify(pubKey PublicKey, data []byte) bool {
-	return ecdsa.Verify(pubKey.Key, data, s.R, s.S)
+	x, y := elliptic.UnmarshalCompressed(elliptic.P256(), pubKey)
+
+	key := &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     x,
+		Y:     y,
+	}
+
+	return ecdsa.Verify(key, data, s.R, s.S)
 }

--- a/notes.md
+++ b/notes.md
@@ -48,7 +48,7 @@ parallel implemenation, and especially subbing our the tests, which lead to a lo
 
 
 
-# Implement TCP transport
+Implement TCP transport
 
 The big learning lesson is that we fucked up the initial transport design.
 


### PR DESCRIPTION
make it a wire-friendly type, []byte
get rid of nasty init gob.Register