### PR TITLE
make block syncing work with tcp transport

### DIFF
--- a/api/status_message.go
+++ b/api/status_message.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"net"
-
 	"github.com/krehermann/goblockchain/core"
 )
 
@@ -17,16 +15,18 @@ type StatusMessageRequest struct {
 }
 
 type SubscribeMessageResponse struct {
+	ProviderId string
 }
 
 type SubscribeMessageRequest struct {
-	RequestorID   string
-	RequestorAddr net.Addr
+	RequestorID string
+	Handle      string
+	//RequestorAddr net.Addr
 }
 
 type GetBlocksRequest struct {
-	RequestorID   string
-	RequestorAddr net.Addr
+	RequestorID string
+	//RequestorAddr net.Addr
 
 	StartHeight uint32
 }

--- a/network/transport.go
+++ b/network/transport.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net"
 )
@@ -14,7 +15,9 @@ type Transport interface {
 	Send(net.Addr, Payload) error
 	Addr() net.Addr
 
-	IsConnected(net.Addr) bool
+	//IsConnected(net.Addr) bool
+	Get(string) (Pipe, bool)
+	Broadcast(Payload) error
 }
 
 type Payload struct {
@@ -27,4 +30,27 @@ func (p Payload) Reader() io.Reader {
 
 func CreatePayload(d []byte) Payload {
 	return Payload{data: d}
+}
+
+type Pipe interface {
+	LocalAddr() net.Addr
+	RemoteAddr() net.Addr
+	String() string
+}
+
+type pipeImpl struct {
+	local  net.Addr
+	remote net.Addr
+}
+
+func (p *pipeImpl) LocalAddr() net.Addr {
+	return p.local
+}
+
+func (p *pipeImpl) RemoteAddr() net.Addr {
+	return p.remote
+}
+
+func (p *pipeImpl) String() string {
+	return fmt.Sprintf("%s (local) -> %s (remote)", p.local.String(), p.remote.String())
 }

--- a/server/handle_subscribe.go
+++ b/server/handle_subscribe.go
@@ -13,19 +13,24 @@ func (s *Server) handleSubscribeMessageRequest(smsg *api.SubscribeMessageRequest
 	)
 
 	// add the requestor to my peers
-	exists := s.Transport.IsConnected(smsg.RequestorAddr)
+	//exists := s.Transport.IsConnected(smsg.RequestorAddr)
+	pipe, exists := s.Transport.Get(smsg.Handle)
 	if !exists {
 		return fmt.Errorf("subscription request from ghost connection %+v", smsg)
 	}
 
-	s.Peers = append(s.Peers, smsg.RequestorAddr)
-
-	resp, err := api.NewMessageFromSubscribeMessageResponse(new(api.SubscribeMessageResponse))
+	//s.Peers = append(s.Peers, pipe)
+	s.Peers.add(smsg.RequestorID, pipe)
+	s.logger.Debug("added subscriber", zap.String("id", smsg.RequestorID))
+	msg := &api.SubscribeMessageResponse{
+		ProviderId: s.Transport.Addr().String(),
+	}
+	resp, err := api.NewMessageFromSubscribeMessageResponse(msg)
 	if err != nil {
 		return err
 	}
 
-	return s.send(smsg.RequestorAddr, resp)
+	return s.send(pipe.RemoteAddr(), resp)
 }
 
 func (s *Server) handleSubscribeMessageResponse(smsg *api.SubscribeMessageResponse) error {
@@ -33,5 +38,12 @@ func (s *Server) handleSubscribeMessageResponse(smsg *api.SubscribeMessageRespon
 		zap.Any("subscribed to", smsg),
 	)
 
+	pipe, exists := s.Transport.Get(smsg.ProviderId)
+	if !exists {
+		return fmt.Errorf("subscription response from ghost connection %+v", smsg)
+	}
+
+	//s.Peers = append(s.Peers, pipe)
+	s.Peers.add(smsg.ProviderId, pipe)
 	return nil
 }


### PR DESCRIPTION
the crux here, again, was  bad interface choice in the transport layer at the beginning of the project.

the server needs to send blocks to somewhere. in tcp, the connections for this communication are hidden in the transport layer. this is fine and good. the problem is that since they are hidden, we need bookkeeping to map from some peer-server identifier to the actual connection to be use for sending

the original transport layer intermixed the notion of connections and transportation and made implicit assumptions about the mapping from peer-server id to connection. it got away with this because the local transport did not have any notion of connection -- the transport was the connection and it was 1:1. in tcp we have a listener and spawned connections. the transport is not 1:1 with a connection.